### PR TITLE
Refactor `CalendarTableCommand` to Enhance Default Configuration Hand…

### DIFF
--- a/src/Commands/CalendarTableCommand.php
+++ b/src/Commands/CalendarTableCommand.php
@@ -39,7 +39,7 @@ class CalendarTableCommand extends Command
     {
         parent::__construct();
 
-        $this->tableName = config('calendar-table.table_name');
+        $this->tableName = config('calendar-table.table_name','date_dimension');
     }
 
     /**
@@ -187,7 +187,7 @@ class CalendarTableCommand extends Command
     public function determineSeason(Carbon $date): string
     {
         // Determine the season
-        return collect(config('calendar-table.seasons'))->filter(function ($startMonth) use ($date) {
+        return collect(config('calendar-table.seasons'), [])->filter(function ($startMonth) use ($date) {
             return $date->month >= $startMonth;
         })->keys()->last() ?? 'Winter';
     }
@@ -203,7 +203,7 @@ class CalendarTableCommand extends Command
         $fiscalYear = $date->year;
         $fiscalQuarter = ceil($date->month / 3);
 
-        $fiscalYearStartMonth = config('calendar-table.fiscal_year_start_month');
+        $fiscalYearStartMonth = config('calendar-table.fiscal_year_start_month', 10);
         if ($date->month >= $fiscalYearStartMonth) {
             $fiscalYear++;
             $fiscalQuarter = ceil(($date->month - $fiscalYearStartMonth + 1) / 3);


### PR DESCRIPTION
I made this change because when using config:cache, Artisan was returning an error and I couldn't resolve it. I had to reinstall via Composer.

Details:

- Updated the `CalendarTableCommand` class to include default values for `table_name` and `fiscal_year_start_month` within the configuration fetching methods. This ensures the command remains functional even if specific configurations are not set by the user.
- Introduced a default return value for the `collect(config('calendar-table.seasons'), [])` call, enhancing robustness by providing a fallback in case the `seasons` configuration is missing.
- Streamlined the handling of fiscal year and quarter calculations by setting a default start month (`fiscal_year_start_month`), thereby accommodating fiscal year configurations that might differ from the calendar year.


These changes improve the command's fault tolerance and user experience by providing sensible defaults. It mitigates potential errors arising from missing configurations, making the command more resilient and user-friendly.